### PR TITLE
remove websocketd access from wazo-calld

### DIFF
--- a/etc/wazo-auth-keys/config.yml
+++ b/etc/wazo-auth-keys/config.yml
@@ -71,8 +71,6 @@ wazo-calld:
     - 'phoned.endpoints.*.hold.start'
     - 'phoned.endpoints.*.hold.stop'
     - 'phoned.endpoints.*.answer'
-    - 'websocketd'
-    - 'websocketd.#'
 
 wazo-chatd:
   system_user: wazo-chatd


### PR DESCRIPTION
reason: used by mongooseim