### PR TITLE
default-user-policy: restrict token expiration events

### DIFF
--- a/etc/wazo-auth/conf.d/50-wazo-default-policies.yml
+++ b/etc/wazo-auth/conf.d/50-wazo-default-policies.yml
@@ -43,7 +43,7 @@ default_policies:
       - 'dird.graphql.me'
       - 'dird.personal.#'
       - 'events.auth.users.me.external.#'
-      - 'events.auth.users.me.sessions.*.expire_soon'
+      - 'events.auth.users.me.sessions.my_session.expire_soon'
       - 'events.call_log.user.me.created'
       - 'events.calls.me'
       - 'events.chat.message.*.me'


### PR DESCRIPTION
Why:

* only receive expiration events for the current session
* Receiving events about other sessions can lead to the creation of
multiple tokens unnecessarily