### PR TITLE
add missing agents statistic access

### DIFF
--- a/etc/wazo-auth/conf.d/50-wazo-default-policies.yml
+++ b/etc/wazo-auth/conf.d/50-wazo-default-policies.yml
@@ -71,6 +71,7 @@ default_policies:
       - 'auth.policies.#'
       - 'auth.tenants.#'
       - 'auth.users.#'
+      - 'call-logd.agents.#'
       - 'call-logd.cdr.#'
       - 'call-logd.queues.#'
       - 'calld.trunks.read'


### PR DESCRIPTION
reason: was accidentally removed from the migration into config file