### PR TITLE
Pull request for WAZO-2253-fix-wizard-permission

### DIFF
--- a/etc/wazo-auth-keys/config.yml
+++ b/etc/wazo-auth-keys/config.yml
@@ -190,8 +190,4 @@ wazo-webhookd:
 xivo-wizard:
   system_user: www-data
   acl:
-    - 'auth.policies.read'
-    - 'auth.users.*.policies.*.create'
-    - 'auth.users.create'
-    - 'provd.cfg_mgr.configs.create'
-    - 'provd.status.read'
+    - '#'

--- a/etc/wazo-auth-keys/config.yml
+++ b/etc/wazo-auth-keys/config.yml
@@ -187,7 +187,7 @@ wazo-webhookd:
     - 'auth.users.*.external.mobile.read'
     - 'auth.users.*.read'
 
-xivo-wizard:
+wazo-wizard:
   system_user: www-data
   acl:
     - '#'


### PR DESCRIPTION
## add '#' access to wizard

why: because it associates admin user to admin policy and need to have
at least the same access than admin-policy

## rename xivo-wizard to wazo-wizard