### PR TITLE
use docker-compose from binary instead of python

### DIFF
--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -1,8 +1,6 @@
 https://github.com/wazo-platform/wazo-lib-rest-client/archive/master.zip
 https://github.com/wazo-platform/wazo-auth-client/archive/master.zip
 https://github.com/wazo-platform/wazo-test-helpers/archive/master.zip
-docker
-docker-compose
 pyhamcrest
 pytest
 pyyaml


### PR DESCRIPTION
why: to have the latest docker-compose