### PR TITLE
WAZO-2938: add `user_admin_status` metadata plugin by default

### DIFF
--- a/etc/wazo-auth/conf.d/50-wazo-default.yml
+++ b/etc/wazo-auth/conf.d/50-wazo-default.yml
@@ -82,3 +82,9 @@ tenant_default_groups:
   wazo_default_admin_group:
     policies:
       wazo_default_admin_policy: true
+
+enabled_metadata_plugins:
+  user_admin_status: true
+
+purpose_metadata_mapping:
+  user: [user_admin_status]


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-auth/pull/256

Why:

* Adds `admin` key into metadata, allowing to know if user is admin for it's tenant or not directly from token