### PR TITLE
fix tox.ini for tox4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 envlist = py37, pycodestyle, pylint
-skipsdist=True
+skipsdist = false
 
 [testenv]
 basepython = python3.7
@@ -22,7 +22,7 @@ commands =
     -sh -c 'pycodestyle --ignore=E501 wazo_auth_keys > pycodestyle.txt'
 deps =
     pycodestyle
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:pylint]
@@ -31,11 +31,11 @@ commands =
 deps =
     -rrequirements.txt
     pylint
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:integration]
-usedevelop = true
+use_develop = true
 deps = -rintegration_tests/test-requirements.txt
 changedir = integration_tests
 passenv =
@@ -43,7 +43,7 @@ passenv =
 commands =
     make test-setup
     pytest -v {posargs}
-whitelist_externals =
+allowlist_externals =
     sh
     make
 


### PR DESCRIPTION
changes:

* skipsdist and usedevelop are now mutually exclusive
* usedevelop -> use_develop for future
* whitelist_externals -> allowlist_externals