### PR TITLE
users: give all permissions on call-logd user API

### DIFF
--- a/etc/wazo-auth/conf.d/50-wazo-default.yml
+++ b/etc/wazo-auth/conf.d/50-wazo-default.yml
@@ -11,7 +11,7 @@ default_policies:
       - 'auth.users.me.sessions.read'
       - 'auth.users.me.tokens.*.delete'
       - 'auth.users.me.tokens.read'
-      - 'call-logd.users.me.cdr.read'
+      - 'call-logd.users.me.#'
       - 'calld.lines.*.presences.read'
       - 'calld.parkings.#'
       - 'calld.switchboards.#'


### PR DESCRIPTION
Why:

* Avoid modifying ACL each time we add a new API