### PR TITLE
calld: add call-logd transcriptions ACLs

### DIFF
--- a/etc/wazo-auth-keys/config.yml
+++ b/etc/wazo-auth-keys/config.yml
@@ -94,6 +94,7 @@ wazo-calld:
     - 'amid.action.ShowDialplan.create'
     - 'auth.tenants.read'
     - 'auth.users.*.tokens.read'
+    - 'call-logd.voicemails.transcriptions.read'
     - 'confd.#'
     - 'phoned.endpoints.*.hold.start'
     - 'phoned.endpoints.*.hold.stop'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new ACL permission for `wazo-calld`, expanding what it can read from `call-logd` (voicemail transcriptions). Risk is limited but touches authorization scopes, so incorrect permissioning could expose transcription data.
> 
> **Overview**
> Updates `etc/wazo-auth-keys/config.yml` to grant **`wazo-calld`** the additional ACL `call-logd.voicemails.transcriptions.read`, allowing it to read voicemail transcription data from `call-logd`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b5c93a9e509f4b821a95f9481afbe6259d340c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->