### PR TITLE
chatd: add ACL for user identities read

### DIFF
--- a/etc/wazo-auth/conf.d/50-wazo-default.yml
+++ b/etc/wazo-auth/conf.d/50-wazo-default.yml
@@ -21,6 +21,7 @@ default_policies:
       - 'calld.users.me.#'
       - 'calld.users.me.conferences.*.participants.read'
       - 'chatd.users.*.presences.read'
+      - 'chatd.users.me.identities.read'
       - 'chatd.users.me.presences.update'
       - 'chatd.users.me.rooms.#'
       - 'chatd.users.presences.read'


### PR DESCRIPTION
## Summary
- Add `chatd.users.me.identities.read` to the default user policy so users can read their own chatd identities (needed for chatd connectors).

## Test plan
- [ ] Verify the policy is applied on a fresh install
- [ ] Confirm a user can call the chatd identities read endpoint with the default policy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single configuration-only ACL expansion scoped to `users.me`; minimal blast radius beyond enabling an additional read endpoint.
> 
> **Overview**
> Updates the default Wazo user policy (`etc/wazo-auth/conf.d/50-wazo-default.yml`) to grant the new ACL `chatd.users.me.identities.read`, allowing users with the default policy to read their own Chatd identities (e.g., for connectors).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e55a47482afb667c0c5fa6e447376cbf4d02fdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->