### PR TITLE
[ITEM-394] Surface voicemail redirections in CDR

### DIFF
--- a/etc/wazo-auth-keys/config.yml
+++ b/etc/wazo-auth-keys/config.yml
@@ -64,6 +64,7 @@ wazo-call-logd:
     - 'confd.contexts.read'
     - 'confd.lines.read'
     - 'confd.users.*.read'
+    - 'confd.voicemails.read'
 
 wazo-call-logd-export:
   system_user: wazo-call-logd


### PR DESCRIPTION
wazo-call-logd reads voicemails from confd to resolve the voicemail
destination details on CDRs when a call is redirected to a voicemail.
Without this ACL the lookup returns 401 and the destination is not resolved.

ITEM-394

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single read-only ACL entry for an internal service; aligns with existing confd read grants and does not broaden write or admin access.
> 
> **Overview**
> Grants **`wazo-call-logd`** the **`confd.voicemails.read`** ACL in `etc/wazo-auth-keys/config.yml` so its service token can list/read voicemails from confd when enriching CDRs for calls redirected to voicemail.
> 
> Without this permission, those confd lookups return **401** and voicemail destination details are missing from CDR output (ITEM-394).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43603d6e9fe69897f8053987ad824fb975a6245b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->