### PR TITLE
[ITEM-407] feat: grant end-users the auth_user_deleted event (own uuid)

### DIFF
--- a/etc/wazo-auth/conf.d/50-wazo-default.yml
+++ b/etc/wazo-auth/conf.d/50-wazo-default.yml
@@ -41,6 +41,7 @@ default_policies:
       - 'dird.directories.personal.*.read'
       - 'dird.graphql.me'
       - 'dird.personal.#'
+      - 'events.auth.users.me.deleted'
       - 'events.auth.users.me.external.#'
       - 'events.auth.users.me.sessions.my_session.expire_soon'
       - 'events.call_log.user.me.created'


### PR DESCRIPTION
## Summary of the changes

- Add `events.auth.users.me.deleted` to `wazo_default_user_policy`

This lets an end-user receive the new `auth_user_deleted` event over the websocket **for their own user only**. The `me` placeholder resolves to the token's own `user_uuid`, so the matching ACL is `events.auth.users.{own_uuid}.deleted` — a user can never receive another user's deletion event. Tenant isolation is enforced by websocketd via the event's `tenant_uuid` (the event extends `UserEvent` → `TenantEvent`). Admins already cover it via `events.#`.

Without this grant the feature silently no-ops for end-users (they wouldn't receive their own deletion).

### Related
- wazo-bus: https://github.com/wazo-platform/wazo-bus/pull/147 (adds `UserDeletedEvent`)
- wazo-auth: https://github.com/wazo-platform/wazo-auth/pull/446 (publishes it)

## How to test

- As a regular user, open a websocket and subscribe to `auth_user_deleted`; have an admin `DELETE /users/{your_uuid}` → you receive the event.
- Confirm a user does NOT receive `auth_user_deleted` when a *different* user in the same tenant is deleted.