### PR TITLE
phoned: add missing ACL for external (office365, Google) contacts

### DIFF
--- a/etc/wazo-auth-keys/config.yml
+++ b/etc/wazo-auth-keys/config.yml
@@ -155,6 +155,7 @@ wazo-phoned:
     - 'amid.action.Command.create'
     - 'amid.action.PJSIPNotify.create'
     - 'auth.tenants.read'
+    - 'auth.users.*.external.*.read'
     - 'auth.users.*.read'
     - 'confd.extensions.features.read'
     - 'confd.users.*.read'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single read-only auth ACL entry aligned with other Wazo daemons; no logic or broader permission changes.
> 
> **Overview**
> Grants **wazo-phoned** the `auth.users.*.external.*.read` permission in `etc/wazo-auth-keys/config.yml`, matching what **wazo-agid** and **wazo-chatd** already use so phoned can read external contact integrations (e.g. Office 365, Google) when serving directory/phone features.
> 
> This is a one-line ACL addition only; no application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fddae6adaad65e2e1e75c3422ca6fb7fff582513. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->